### PR TITLE
Default advanced output resolution

### DIFF
--- a/source/OBS_service.cpp
+++ b/source/OBS_service.cpp
@@ -867,29 +867,32 @@ bool OBS_service::resetVideoContext(const char* outputType)
 
 	if (outputMode == NULL) {
 		outputMode = "Simple";
-	}
+    }
+
+    ovi.output_width   = (uint32_t)config_get_uint(basicConfig, "Video", "OutputCX");
+    ovi.output_height  = (uint32_t)config_get_uint(basicConfig, "Video", "OutputCY");
 
     if(strcmp(outputMode, "Advanced") == 0 && outputType != NULL) {
         if(strcmp(outputType, "Stream") == 0) {
-            const char* rescaleRes = config_get_string(basicConfig, "AdvOut", "RescaleRes");
-            if (rescaleRes == NULL) {
-                rescaleRes = "1280x720";
+            bool doRescale = config_get_bool(basicConfig, "AdvOut", "Rescale");
+            if(doRescale) {
+                const char* rescaleRes = config_get_string(basicConfig, "AdvOut", "RescaleRes");
+                if (rescaleRes == NULL) {
+                    rescaleRes = "1280x720";
+                }
+                sscanf(rescaleRes, "%ux%u", &ovi.output_width, &ovi.output_height);
             }
-            sscanf(rescaleRes, "%ux%u", &ovi.output_width, &ovi.output_height);
         } else if (strcmp(outputType, "Record") == 0) {
-            const char* recRescaleRes = config_get_string(basicConfig, "AdvOut", "RecRescaleRes");
-            if (recRescaleRes == NULL) {
-                recRescaleRes = "1280x720";
+            bool doRescale = config_get_bool(basicConfig, "AdvOut", "RecRescale");
+            if(doRescale) {
+                const char* recRescaleRes = config_get_string(basicConfig, "AdvOut", "RecRescaleRes");
+                if (recRescaleRes == NULL) {
+                    recRescaleRes = "1280x720";
+                }
+                sscanf(recRescaleRes, "%ux%u", &ovi.output_width, &ovi.output_height);
             }
-            sscanf(recRescaleRes, "%ux%u", &ovi.output_width, &ovi.output_height);
         }
-
-    } else {
-        ovi.output_width   = (uint32_t)config_get_uint(basicConfig, "Video", "OutputCX");
-        ovi.output_height  = (uint32_t)config_get_uint(basicConfig, "Video", "OutputCY");
     }
-
-
 
 	std::vector<Screen> resolutions = OBS_API::availableResolutions();
 


### PR DESCRIPTION
If custom rescale is not being used, use the output resolution value in the video category.