### PR TITLE
Fix advanced output encoder settings

### DIFF
--- a/source/OBS_settings.cpp
+++ b/source/OBS_settings.cpp
@@ -1140,18 +1140,18 @@ Local<Object> OBS_settings::getAdvancedOutputStreamingSettings(config_t* config)
 	subCategoryParameters->Set(index++, EncoderList);
 	
 	// Enforce streaming service encoder settings : boolean
-	Local<Object> EnforceBitrate = Object::New(isolate);
-	EnforceBitrate->Set(String::NewFromUtf8(isolate, "name"), String::NewFromUtf8(isolate, "EnforceBitrate"));
-	EnforceBitrate->Set(String::NewFromUtf8(isolate, "type"), String::NewFromUtf8(isolate, "OBS_PROPERTY_BOOL"));
-	EnforceBitrate->Set(String::NewFromUtf8(isolate, "description"),
+	Local<Object> ApplyServiceSettings = Object::New(isolate);
+	ApplyServiceSettings->Set(String::NewFromUtf8(isolate, "name"), String::NewFromUtf8(isolate, "ApplyServiceSettings"));
+	ApplyServiceSettings->Set(String::NewFromUtf8(isolate, "type"), String::NewFromUtf8(isolate, "OBS_PROPERTY_BOOL"));
+	ApplyServiceSettings->Set(String::NewFromUtf8(isolate, "description"),
 							String::NewFromUtf8(isolate, "Enforce streaming service encoder settings"));
-	EnforceBitrate->Set(String::NewFromUtf8(isolate, "currentValue"),
-						Integer::New(isolate, config_get_bool(config, "AdvOut", "EnforceBitrate")));
+	ApplyServiceSettings->Set(String::NewFromUtf8(isolate, "currentValue"),
+						Integer::New(isolate, config_get_bool(config, "AdvOut", "ApplyServiceSettings")));
 
-	EnforceBitrate->Set(String::NewFromUtf8(isolate, "visible"), Integer::New(isolate, true));
-	EnforceBitrate->Set(String::NewFromUtf8(isolate, "enabled"), Integer::New(isolate, true));
-	EnforceBitrate->Set(String::NewFromUtf8(isolate, "masked"), Integer::New(isolate, false));
-	subCategoryParameters->Set(index++, EnforceBitrate);
+	ApplyServiceSettings->Set(String::NewFromUtf8(isolate, "visible"), Integer::New(isolate, true));
+	ApplyServiceSettings->Set(String::NewFromUtf8(isolate, "enabled"), Integer::New(isolate, true));
+	ApplyServiceSettings->Set(String::NewFromUtf8(isolate, "masked"), Integer::New(isolate, false));
+	subCategoryParameters->Set(index++, ApplyServiceSettings);
 	
 	// Rescale Output : boolean
 	Local<Object> Rescale = Object::New(isolate);

--- a/source/OBS_settings.cpp
+++ b/source/OBS_settings.cpp
@@ -2236,6 +2236,12 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(Local<Array> settings, st
 	if (ret != 0) {
 		blog(LOG_WARNING, "Failed to config file %s", basicConfigFile.c_str());
 	}
+
+	bool applyServiceSettings = config_get_bool(config, "AdvOut", "ApplyServiceSettings");
+
+	if (applyServiceSettings)
+		obs_service_apply_encoder_settings(OBS_service::getService(), encoderSettings, nullptr);
+
 	obs_encoder_update(encoder, encoderSettings);
 
 	std::string path = OBS_API::getStreamingEncoderConfigPath();

--- a/source/OBS_settings.cpp
+++ b/source/OBS_settings.cpp
@@ -1048,8 +1048,8 @@ void OBS_settings::getEncoderSettings(Isolate *isolate, const char *encoderID, o
 				break;
 			}
 		}
-		entryObject->Set(String::NewFromUtf8(isolate, "visible"), Integer::New(isolate, true));
-		entryObject->Set(String::NewFromUtf8(isolate, "enabled"), Integer::New(isolate, true));
+		entryObject->Set(String::NewFromUtf8(isolate, "visible"), Integer::New(isolate, obs_property_visible(property)));
+		entryObject->Set(String::NewFromUtf8(isolate, "enabled"), Integer::New(isolate, obs_property_enabled(property)));
 		entryObject->Set(String::NewFromUtf8(isolate, "masked"), Integer::New(isolate, false));
 		(*subCategoryParameters)->Set(index++, entryObject);
 		obs_property_next(&property);

--- a/source/OBS_settings.h
+++ b/source/OBS_settings.h
@@ -97,7 +97,7 @@ private:
 																		std::string>>* streamEncoder);
 	static std::vector<pair<int, int>> 		getOutputResolutions	(int base_cx, int base_cy);
 	static void 							getEncoderSettings		(Isolate *isolate,
-																		const char *encoderID,
+																		const obs_encoder_t *encoder,
 																		obs_data_t *settings,
 																		Local<Array>* subCategoryParameters,
 																		int index);


### PR DESCRIPTION
 - Get the visibility and the enability fron the property
 - Apply/Load/Save encoder settings to the current service property
 - Get properties from current encoder instead of the default ones